### PR TITLE
Add delegate methods when Alert events happen

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 					};
 					8EC391801A58B465001C121E = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = HT94948NDD;
+						DevelopmentTeam = YR9AZ3MNS9;
 						DevelopmentTeamName = "Arthur Sabintsev";
 						LastSwiftMigration = 1020;
 						SystemCapabilities = {
@@ -566,11 +566,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = HT94948NDD;
+				DEVELOPMENT_TEAM = YR9AZ3MNS9;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.Facebook;
+				PRODUCT_BUNDLE_IDENTIFIER = it.latergram.latergram;
 				PRODUCT_NAME = Example;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -583,11 +583,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = HT94948NDD;
+				DEVELOPMENT_TEAM = YR9AZ3MNS9;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.Facebook;
+				PRODUCT_BUNDLE_IDENTIFIER = it.latergram.latergram;
 				PRODUCT_NAME = Example;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -27,16 +27,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 //        forceLocalizationCustomizationPresentationExample()
 //        customMessagingPresentationExample()
 //        annoyingRuleExample()
-        hyperCriticalRulesExample()
+//        hyperCriticalRulesExample()
 //        updateSpecificRulesExample()
 //        customAlertRulesExample()
 //        appStoreCountryChangeExample()
 //        complexExample()
-
+        conditionalRules()
         return true
     }
 }
-
 // Examples on how to use Siren
 
 private extension AppDelegate {
@@ -266,4 +265,31 @@ private extension AppDelegate {
             }
         }
     }
+    
+    func conditionalRules() {
+        let siren = Siren.shared
+        siren.delegate = self
+        siren.presentationManager = PresentationManager(nextTimeButtonTitle: "My Next", skippableAfter: 2)
+        let rules = GlobalConditionalRules(promptFrequency: .immediately, voluntary: 3, involuntary: 6, majorInvoluntary: 3)
+        siren.rulesManager = RulesManager(globalRules: rules, showAlertAfterCurrentVersionHasBeenReleasedForDays: 1)
+        siren.wail(performCheck: .onDemand) { _ in }
+    }
 }
+
+extension AppDelegate: SirenDelegate {
+    func didShowAlert(currentVersion: String, targetVersion: String, alertType: Rules.AlertType) {
+        print(#function)
+        print("currentVersion", currentVersion, "targetVersion", targetVersion, "alertType", alertType)
+    }
+    
+    func didSkipUpdate(currentVersion: String, targetVersion: String, alertType: Rules.AlertType) {
+        print(#function)
+        print("currentVersion", currentVersion, "targetVersion", targetVersion, "alertType", alertType)
+    }
+    
+    func didConfirmUpdate(currentVersion: String, targetVersion: String, alertType: Rules.AlertType) {
+        print(#function)
+        print("currentVersion", currentVersion, "targetVersion", targetVersion, "alertType", alertType)
+    }
+}
+

--- a/Sources/Managers/PresentationManager.swift
+++ b/Sources/Managers/PresentationManager.swift
@@ -11,7 +11,7 @@ import UIKit
 /// PresentationManager for Siren
 public class PresentationManager {
     /// Return results or errors obtained from performing a version check with Siren.
-    typealias CompletionHandler = (AlertAction, String?) -> Void
+    typealias CompletionHandler = (AlertAction) -> Void
 
     /// The localization data structure that will be used to construct localized strings for the update alert.
     let localization: Localization
@@ -169,7 +169,7 @@ extension PresentationManager {
             alertController?.addAction(nextTimeAlertAction(completion: handler))
             alertController?.addAction(skipAlertAction(forCurrentAppStoreVersion: currentAppStoreVersion, completion: handler))
         case .none:
-            handler?(.unknown, nil)
+            handler?(.unknown)
         }
 
         // If the alertType is .none, an alert will not be presented.
@@ -211,7 +211,7 @@ private extension PresentationManager {
 
         let action = UIAlertAction(title: title, style: .default) { _ in
             self.cleanUp()
-            handler?(.appStore, nil)
+            handler?(.appStore)
             UserDefaults.showTimes = 0
             return
         }
@@ -234,7 +234,7 @@ private extension PresentationManager {
 
         let action = UIAlertAction(title: title, style: .default) { _ in
             self.cleanUp()
-            handler?(.nextTime, nil)
+            handler?(.nextTime)
             UserDefaults.showTimes += 1
             return
         }
@@ -258,7 +258,7 @@ private extension PresentationManager {
 
         let action = UIAlertAction(title: title, style: .default) { _ in
             self.cleanUp()
-            handler?(.skip, currentAppStoreVersion)
+            handler?(.skip)
             UserDefaults.showTimes = 0
             return
         }


### PR DESCRIPTION
Changes in this repository are required to be done before completing https://latergramme.atlassian.net/browse/IO-3652

Created protocol `SirenDelegate`
```
public protocol SirenDelegate: AnyObject {
    func didShowAlert(currentVersion: String, targetVersion: String, alertType: Rules.AlertType)
    func didSkipUpdate(currentVersion: String, targetVersion: String, alertType: Rules.AlertType)
    func didConfirmUpdate(currentVersion: String, targetVersion: String, alertType: Rules.AlertType)
}
``` 
The events are called when a UIAlertAction fires (`processAlertAction()` in `Siren.swift`)

To test play with app vertsion that you can set in `Targets/Example` -> `Info` -> `Bundle version string (short)` and observe console for the events.



